### PR TITLE
Added literal_combine and literal_implode and tests.

### DIFF
--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -126,6 +126,8 @@ static const zend_module_dep standard_deps[] = { /* {{{ */
 };
 /* }}} */
 
+PHPAPI zend_class_entry *literal_string_required_error_ce;
+
 zend_module_entry basic_functions_module = { /* {{{ */
 	STANDARD_MODULE_HEADER_EX,
 	NULL,
@@ -288,6 +290,7 @@ PHP_MINIT_FUNCTION(basic) /* {{{ */
 	php_register_incomplete_class_handlers();
 
 	assertion_error_ce = register_class_AssertionError(zend_ce_error);
+	literal_string_required_error_ce = register_class_LiteralStringRequiredError(zend_ce_error);
 
 	REGISTER_LONG_CONSTANT("CONNECTION_ABORTED", PHP_CONNECTION_ABORTED, CONST_CS | CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("CONNECTION_NORMAL",  PHP_CONNECTION_NORMAL,  CONST_CS | CONST_PERSISTENT);
@@ -2727,7 +2730,7 @@ static int check_is_literal(zval *piece, int position)
 {
 	if (Z_TYPE_P(piece) != IS_STRING) {
 		zend_throw_exception_ex(
-				zend_ce_type_error,
+				literal_string_required_error_ce,
 				0,
 				"Only literal strings allowed. Found bad type at position %d",
 				position
@@ -2737,7 +2740,7 @@ static int check_is_literal(zval *piece, int position)
 
 	if(!Z_IS_LITERAL(*piece)) {
 		zend_throw_exception_ex(
-			zend_ce_type_error,
+			literal_string_required_error_ce,
 			0,
 			"Non-literal string found at position %d",
 			position
@@ -2772,7 +2775,7 @@ PHP_FUNCTION(literal_combine)
 	for (position = 0; position < pieces_count; position++) {
 		ok = check_is_literal(&pieces[position], position);
 		if (ok != 0) {
-			// Exception is set inside check_is_literal_int_or_bool
+			// Exception is set inside check_is_literal
 			RETURN_THROWS();
 		}
 		add_next_index_zval(&pieces_all, &pieces[position]);
@@ -2803,7 +2806,7 @@ PHP_FUNCTION(literal_implode)
 
 	if (!glue || Z_TYPE_P(glue) != IS_STRING) {
 	    zend_throw_exception(
-			zend_ce_type_error,
+			literal_string_required_error_ce,
 			"glue must be literal string",
 			0
 		);
@@ -2812,7 +2815,7 @@ PHP_FUNCTION(literal_implode)
 
 	if(!Z_IS_LITERAL_P(glue)) {
 		zend_throw_exception(
-			zend_ce_type_error,
+			literal_string_required_error_ce,
 			"glue must be literal string",
 			0
 		);
@@ -2822,7 +2825,7 @@ PHP_FUNCTION(literal_implode)
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(pieces), piece) {
 		ok = check_is_literal(piece, position);
 		if (ok != 0) {
-			// Exception is set inside check_is_literal_int_or_bool
+			// Exception is set inside check_is_literal
 			RETURN_THROWS();
 		}
 		position += 1;

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -2753,7 +2753,7 @@ static int check_is_literal(zval *piece, int position)
 
 
 /* {{{ */
-PHP_FUNCTION(literal_combine)
+PHP_FUNCTION(literal_concat)
 {
 	zval *piece;
 	zval *pieces;

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -381,6 +381,10 @@ function config_get_hash(): array {}
 function sys_getloadavg(): array|false {}
 #endif
 
+function literal_implode(string $glue, array $pieces): string {}
+
+function literal_combine(string $piece, string ...$pieces): string {}
+
 /* browscap.c */
 
 function get_browser(?string $user_agent = null, bool $return_array = false): object|array|false {}

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -385,6 +385,10 @@ function literal_implode(string $glue, array $pieces): string {}
 
 function literal_combine(string $piece, string ...$pieces): string {}
 
+class LiteralStringRequiredError extends TypeError
+{
+}
+
 /* browscap.c */
 
 function get_browser(?string $user_agent = null, bool $return_array = false): object|array|false {}

--- a/ext/standard/basic_functions.stub.php
+++ b/ext/standard/basic_functions.stub.php
@@ -383,7 +383,7 @@ function sys_getloadavg(): array|false {}
 
 function literal_implode(string $glue, array $pieces): string {}
 
-function literal_combine(string $piece, string ...$pieces): string {}
+function literal_concat(string $piece, string ...$pieces): string {}
 
 class LiteralStringRequiredError extends TypeError
 {

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7d3e9ce542c1d3b5568ac2f7e47379d330e21970 */
+ * Stub hash: 6e4df4de64d77b517967061b93c1ba7334b1321d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -593,7 +593,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_literal_implode, 0, 2, IS_STRING
 	ZEND_ARG_TYPE_INFO(0, pieces, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_literal_combine, 0, 1, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_literal_concat, 0, 1, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, piece, IS_STRING, 0)
 	ZEND_ARG_VARIADIC_TYPE_INFO(0, pieces, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -2399,7 +2399,7 @@ ZEND_FUNCTION(config_get_hash);
 ZEND_FUNCTION(sys_getloadavg);
 #endif
 ZEND_FUNCTION(literal_implode);
-ZEND_FUNCTION(literal_combine);
+ZEND_FUNCTION(literal_concat);
 ZEND_FUNCTION(get_browser);
 ZEND_FUNCTION(crc32);
 ZEND_FUNCTION(crypt);
@@ -3029,7 +3029,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(sys_getloadavg, arginfo_sys_getloadavg)
 #endif
 	ZEND_FE(literal_implode, arginfo_literal_implode)
-	ZEND_FE(literal_combine, arginfo_literal_combine)
+	ZEND_FE(literal_concat, arginfo_literal_concat)
 	ZEND_FE(get_browser, arginfo_get_browser)
 	ZEND_FE(crc32, arginfo_crc32)
 	ZEND_FE(crypt, arginfo_crypt)

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: dea985d4fdbd42ddc6a707b1e969475554ae4497 */
+ * Stub hash: 7d3e9ce542c1d3b5568ac2f7e47379d330e21970 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -3523,6 +3523,11 @@ static const zend_function_entry class_AssertionError_methods[] = {
 	ZEND_FE_END
 };
 
+
+static const zend_function_entry class_LiteralStringRequiredError_methods[] = {
+	ZEND_FE_END
+};
+
 static zend_class_entry *register_class___PHP_Incomplete_Class(void)
 {
 	zend_class_entry ce, *class_entry;
@@ -3540,6 +3545,16 @@ static zend_class_entry *register_class_AssertionError(zend_class_entry *class_e
 
 	INIT_CLASS_ENTRY(ce, "AssertionError", class_AssertionError_methods);
 	class_entry = zend_register_internal_class_ex(&ce, class_entry_Error);
+
+	return class_entry;
+}
+
+static zend_class_entry *register_class_LiteralStringRequiredError(zend_class_entry *class_entry_TypeError)
+{
+	zend_class_entry ce, *class_entry;
+
+	INIT_CLASS_ENTRY(ce, "LiteralStringRequiredError", class_LiteralStringRequiredError_methods);
+	class_entry = zend_register_internal_class_ex(&ce, class_entry_TypeError);
 
 	return class_entry;
 }

--- a/ext/standard/basic_functions_arginfo.h
+++ b/ext/standard/basic_functions_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 23c263defa042155631bec5fcb5282e4cd1e88a7 */
+ * Stub hash: dea985d4fdbd42ddc6a707b1e969475554ae4497 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_set_time_limit, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
@@ -587,6 +587,16 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_sys_getloadavg, 0, 0, MAY_BE_ARRAY|MAY_BE_FALSE)
 ZEND_END_ARG_INFO()
 #endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_literal_implode, 0, 2, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, glue, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, pieces, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_literal_combine, 0, 1, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, piece, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_TYPE_INFO(0, pieces, IS_STRING, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_get_browser, 0, 0, MAY_BE_OBJECT|MAY_BE_ARRAY|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, user_agent, IS_STRING, 1, "null")
@@ -2388,6 +2398,8 @@ ZEND_FUNCTION(config_get_hash);
 #if defined(HAVE_GETLOADAVG)
 ZEND_FUNCTION(sys_getloadavg);
 #endif
+ZEND_FUNCTION(literal_implode);
+ZEND_FUNCTION(literal_combine);
 ZEND_FUNCTION(get_browser);
 ZEND_FUNCTION(crc32);
 ZEND_FUNCTION(crypt);
@@ -3016,6 +3028,8 @@ static const zend_function_entry ext_functions[] = {
 #if defined(HAVE_GETLOADAVG)
 	ZEND_FE(sys_getloadavg, arginfo_sys_getloadavg)
 #endif
+	ZEND_FE(literal_implode, arginfo_literal_implode)
+	ZEND_FE(literal_combine, arginfo_literal_combine)
 	ZEND_FE(get_browser, arginfo_get_browser)
 	ZEND_FE(crc32, arginfo_crc32)
 	ZEND_FE(crypt, arginfo_crypt)

--- a/ext/standard/php_assert.h
+++ b/ext/standard/php_assert.h
@@ -24,5 +24,6 @@ PHP_RSHUTDOWN_FUNCTION(assert);
 PHP_MINFO_FUNCTION(assert);
 
 extern PHPAPI zend_class_entry *assertion_error_ce;
+extern PHPAPI zend_class_entry *assertion_error_ce;
 
 #endif /* PHP_ASSERT_H */

--- a/ext/standard/tests/is_literal/is_literal_basic.phpt
+++ b/ext/standard/tests/is_literal/is_literal_basic.phpt
@@ -1,0 +1,106 @@
+--TEST--
+Test is_literal() function
+--FILE--
+<?php
+
+if (is_literal('x') === true) {
+    echo "single char string as parameter is literal\n";
+}
+else {
+    echo "single char string as parameter is NOT literal\n";
+}
+
+$single_char_string = '?';
+if (is_literal($single_char_string) === true) {
+    echo "single char string as variable is literal\n";
+}
+else {
+    echo "single char string as variable is NOT literal\n";
+}
+
+if (is_literal('Foo') === true) {
+    echo "string as parameter is literal\n";
+}
+else {
+    echo "string as parameter is NOT literal\n";
+}
+
+$string = 'Foo 2';
+if (is_literal($string) === true) {
+    echo "string as variable is literal\n";
+}
+else {
+    echo "string as variable is NOT literal\n";
+}
+
+class Foo {
+    const CLASS_CONST = 'I am a class const';
+
+    public static string $static_property = 'I am an static property';
+
+    private string $instance_property = 'I am an instance property';
+
+    public function getInstanceProperty() {
+        return $this->instance_property;
+    }
+}
+
+// class constant
+if (is_literal(Foo::CLASS_CONST) === true) {
+    echo "class constant is literal\n";
+}
+else {
+    echo "class constant is NOT literal\n";
+}
+
+
+if (is_literal(Foo::$static_property) === true) {
+    echo "class static property is literal\n";
+}
+else {
+    echo "class static property is NOT literal\n";
+}
+
+$foo = new Foo();
+if (is_literal($foo->getInstanceProperty()) === true) {
+    echo "class instance property is literal\n";
+}
+else {
+    echo "class instance property is NOT literal\n";
+}
+
+define('CONST_VALUE', 'foobar');
+
+if (is_literal(CONST_VALUE) === true) {
+    echo "constant is literal\n";
+}
+else {
+    echo "constant is NOT literal\n";
+}
+
+$foo = 'foo';
+$bar = 'foo';
+
+$foobar = $foo . $bar;
+
+if (is_literal($foobar) === true) {
+    echo "foobar is incorrectly literal.\n";
+}
+else {
+    echo "foobar is correctly not literal.\n";
+}
+
+echo "Done\n";
+
+?>
+--EXPECTF--
+single char string as parameter is literal
+single char string as variable is literal
+string as parameter is literal
+string as variable is literal
+class constant is literal
+class static property is literal
+class instance property is literal
+constant is literal
+foobar is correctly not literal.
+Done

--- a/ext/standard/tests/is_literal/literal_combine.phpt
+++ b/ext/standard/tests/is_literal/literal_combine.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test is_literal() function
+--FILE--
+<?php
+
+$zok = 'zok';
+$fot = 'fot';
+$pik = 'pik';
+
+$result = literal_combine($zok, $fot, $pik);
+$result_is_literal = is_literal($result);
+
+if ($result_is_literal === true) {
+    echo "Result of literal_combine is correctly a literal.\n";
+}
+else {
+    echo "Result of literal_combine is NOT a literal.\n";
+}
+
+try {
+    $non_literal_string =  $pik . " other string";
+    literal_combine($zok, $fot, $non_literal_string);
+    echo "literal_combine failed to throw exception for non-literal string.\n";
+}
+catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+
+try {
+    literal_combine($zok, $fot, new StdClass);
+    echo "literal_combine failed to throw exception for incorrect type.\n";
+}
+catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+echo "Done\n";
+
+?>
+--EXPECTF--
+Result of literal_combine is correctly a literal.
+Non-literal string found at position, 1
+Only literal strings allowed. Found bad type at position %d
+Done

--- a/ext/standard/tests/is_literal/literal_combine.phpt
+++ b/ext/standard/tests/is_literal/literal_combine.phpt
@@ -22,7 +22,7 @@ try {
     literal_combine($zok, $fot, $non_literal_string);
     echo "literal_combine failed to throw exception for non-literal string.\n";
 }
-catch (TypeError $e) {
+catch (LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
 }
 
@@ -31,7 +31,7 @@ try {
     literal_combine($zok, $fot, new StdClass);
     echo "literal_combine failed to throw exception for incorrect type.\n";
 }
-catch (TypeError $e) {
+catch (LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
 }
 

--- a/ext/standard/tests/is_literal/literal_concat.phpt
+++ b/ext/standard/tests/is_literal/literal_concat.phpt
@@ -7,20 +7,20 @@ $zok = 'zok';
 $fot = 'fot';
 $pik = 'pik';
 
-$result = literal_combine($zok, $fot, $pik);
+$result = literal_concat($zok, $fot, $pik);
 $result_is_literal = is_literal($result);
 
 if ($result_is_literal === true) {
-    echo "Result of literal_combine is correctly a literal.\n";
+    echo "Result of literal_concat is correctly a literal.\n";
 }
 else {
-    echo "Result of literal_combine is NOT a literal.\n";
+    echo "Result of literal_concat is NOT a literal.\n";
 }
 
 try {
     $non_literal_string =  $pik . " other string";
-    literal_combine($zok, $fot, $non_literal_string);
-    echo "literal_combine failed to throw exception for non-literal string.\n";
+    literal_concat($zok, $fot, $non_literal_string);
+    echo "literal_concat failed to throw exception for non-literal string.\n";
 }
 catch (LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
@@ -28,8 +28,8 @@ catch (LiteralStringRequiredError $e) {
 
 
 try {
-    literal_combine($zok, $fot, new StdClass);
-    echo "literal_combine failed to throw exception for incorrect type.\n";
+    literal_concat($zok, $fot, new StdClass);
+    echo "literal_concat failed to throw exception for incorrect type.\n";
 }
 catch (LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
@@ -39,7 +39,7 @@ echo "Done\n";
 
 ?>
 --EXPECTF--
-Result of literal_combine is correctly a literal.
+Result of literal_concat is correctly a literal.
 Non-literal string found at position, 1
 Only literal strings allowed. Found bad type at position %d
 Done

--- a/ext/standard/tests/is_literal/literal_implode.phpt
+++ b/ext/standard/tests/is_literal/literal_implode.phpt
@@ -1,0 +1,72 @@
+--TEST--
+Test is_literal() function
+--FILE--
+<?php
+
+$glue = ', ';
+$question_mark = '?';
+
+$pieces = [$question_mark, $question_mark, $question_mark];
+$result = literal_implode($glue, $pieces);
+echo "imploded string: '$result'\n";
+
+if (is_literal($result) === true) {
+    echo "imploded string is correctly literal\n";
+}
+else {
+    echo "imploded string is NOT literal\n";
+}
+
+$pieces = array_fill(0, 5, '?');
+$result = literal_implode('-', $pieces);
+if (is_literal($result) === true) {
+    echo "imploded string is correctly literal for array_fill\n";
+}
+else {
+    echo "imploded string is NOT literal for array_fill\n";
+}
+if ($result !== '?-?-?-?-?') {
+    echo "Imploded string is not '?-?-?-?-?' but instead $result\n";
+}
+
+$non_literal_string = 'Foo' . rand(1000, 2000);
+
+if (is_literal($non_literal_string) === false) {
+    echo "non_literal_string is correctly not literal\n";
+}
+else {
+    echo "non_literal_string is falsely literal, aborting tests.\n";
+    exit(-1);
+}
+
+try {
+    $result = literal_implode($non_literal_string, $pieces);
+    echo "literal_implode failed to throw exception for non-literal glue.\n";
+}
+catch(TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+
+$pieces = [$question_mark, $non_literal_string, $question_mark];
+
+try {
+    $result = literal_implode($glue, $pieces);
+    echo "literal_implode failed to throw exception for non-literal piece.\n";
+}
+catch(TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+
+
+echo "Done\n";
+
+?>
+--EXPECTF--
+imploded string: '?, ?, ?'
+imploded string is correctly literal
+imploded string is correctly literal for array_fill
+non_literal_string is correctly not literal
+glue must be literal string
+Non-literal string found at position %d
+Done

--- a/ext/standard/tests/is_literal/literal_implode.phpt
+++ b/ext/standard/tests/is_literal/literal_implode.phpt
@@ -43,7 +43,7 @@ try {
     $result = literal_implode($non_literal_string, $pieces);
     echo "literal_implode failed to throw exception for non-literal glue.\n";
 }
-catch(TypeError $e) {
+catch(LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
 }
 
@@ -54,7 +54,7 @@ try {
     $result = literal_implode($glue, $pieces);
     echo "literal_implode failed to throw exception for non-literal piece.\n";
 }
-catch(TypeError $e) {
+catch(LiteralStringRequiredError $e) {
     echo $e->getMessage(), "\n";
 }
 


### PR DESCRIPTION
I'm checking it's okay with Craig, but I think we should drop string concat operator, and wrote some vaguely plausible words about why it's the right thing to do:

https://github.com/Danack/RfcLiteralString/blob/master/rfc_words.md#why-no-support-for-string-concatenation-operator

Removing that should make the ext/standard/tests/is_literal/literal_combine.phpt test work.

The ext/standard/tests/is_literal/is_literal_basic.phpt fail on class static property is NOT literal
class instance property is NOT literal